### PR TITLE
Allow configuration of default image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ You'll also need to update your form's controller. For example, assuming a `User
 User.new(params.require!(:users).permit(:retained_avatar, :remove_avatar, ... ))
 ```
 
+### Default Image
+You can change the default image by running a configuration block (in rails, you would place this in a file inside the config/initializers directory:
+```ruby
+SimpleDragonflyPreview.configure do |config|
+  config.default_image_url = "lorem.png"
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/app/views/simple_dragonfly_preview/image/_form.html.erb
+++ b/app/views/simple_dragonfly_preview/image/_form.html.erb
@@ -8,7 +8,7 @@
           <%= f.check_box("remove_#{attribute_name}") %>
         </div>
       <% else %>
-        <%= image_tag "simple_dragonfly_preview/default.png", id: image_id %>
+        <%= image_tag(SimpleDragonflyPreview.configuration.default_image_url, id: image_id) %>
       <% end %>
     </td>
   </tr>

--- a/lib/simple_dragonfly_preview.rb
+++ b/lib/simple_dragonfly_preview.rb
@@ -1,4 +1,7 @@
+require "simple_dragonfly_preview/config.rb"
 require "simple_dragonfly_preview/engine"
 
 module SimpleDragonflyPreview
 end
+
+SimpleDragonflyPreview.configure {}

--- a/lib/simple_dragonfly_preview/config.rb
+++ b/lib/simple_dragonfly_preview/config.rb
@@ -1,0 +1,18 @@
+module SimpleDragonflyPreview
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration)
+  end
+
+  class Configuration
+    attr_accessor :default_image_url
+
+    def initialize
+      @default_image_url = "simple_dragonfly_preview/default.png"
+    end
+  end
+end

--- a/lib/simple_dragonfly_preview/version.rb
+++ b/lib/simple_dragonfly_preview/version.rb
@@ -1,3 +1,3 @@
 module SimpleDragonflyPreview
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
I've added a bit of boilerplate that allowed me to set a default image instead of the hardcoded default. An upgrade to this version should require no changes for the user, but if they add a configuration block they'll be able to make changes.

[I've followed the configuration pattern from thoughtbot.](http://robots.thoughtbot.com/mygem-configure-block)
