### PR TITLE
Update input definitions to new simple_form specs

### DIFF
--- a/app/inputs/image_preview_input.rb
+++ b/app/inputs/image_preview_input.rb
@@ -1,6 +1,6 @@
 
 class ImagePreviewInput < SimpleForm::Inputs::Base
-  def input
+  def input(wrapper_options = nil)
     resize = options.delete(:size) || '350x100>'
     size = resize.sub(/\D$/,'')
     keys = options.delete(:attribute_keys)


### PR DESCRIPTION
According to https://github.com/plataformatec/simple_form/pull/997,
instead of _def input_, one should use _def input(wrapper_options)_
