### PR TITLE
fix input for nested fields

### DIFF
--- a/app/inputs/image_preview_input.rb
+++ b/app/inputs/image_preview_input.rb
@@ -5,19 +5,23 @@ class ImagePreviewInput < SimpleForm::Inputs::Base
     size = resize.sub(/\D$/,'')
     keys = options.delete(:attribute_keys)
     name = attribute_name.to_s
-    attribute_keys = @builder.object.attributes.keys.inject([]) do |array, x| 
+    attribute_keys = @builder.object.attributes.keys.inject([]) do |array, x|
       n, a = x.split("_")
-      n == name && a.present? ? array << a : array 
+      n == name && a.present? ? array << a : array
     end
 
-    template.render("simple_dragonfly_preview/image/form", 
-      f: @builder, 
-      attribute_name: name, 
-      retained_id: (@builder.lookup_model_names + ["retained", name]).join("_"), 
-      image_id: (@builder.lookup_model_names + [name, "preview"]).join("_"),
-      size: size, 
+    template.render("simple_dragonfly_preview/image/form",
+      f: @builder,
+      attribute_name: name,
+      retained_id: ([field_name, "retained", name]).join("_"),
+      image_id: ([field_name, name, "preview"]).join("_"),
+      size: size,
       resize: resize,
       attribute_keys: attribute_keys.join(","))
+  end
+
+  def field_name
+    object_name.split(/\[|\]/).reject(&:empty?).join('_')
   end
 end
 


### PR DESCRIPTION
Hey there !

I was looking for a nice way to manage the photo albums on a project and the great almighty Google made me discover this nice project.

Only small bump on the road, you're not really nested form friendly....

```
= simple_form_for album do |f|
  = f.simple_fields_for :photos do |fp|
    = fp.input :picture, as: :image_preview, size: "350x140#"
```

The problem was that the retainer_id and image_id were wrong (album_photo_retained_image / album_photo_image_preview instead of album_photos_attributes_0_retained_image / album_photos_attributes_0_image_preview)

So, here's a small patch !
